### PR TITLE
Initialize vault adoption dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VAULT_ADDR=https://vault.mycompany.com
+VAULT_TOKEN=s.xxxxxxxx

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# vault-dashboard
+# Vault Adoption Dashboard
+
+A gamified dashboard that visualizes Vault usage based on API responses.
+
+## Setup
+
+```bash
+npm install
+cp .env.example .env # edit with your Vault address and token
+```
+
+## Development
+
+```bash
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+Deploy the `dist` directory to your preferred static host (e.g. Vercel or GitHub Pages).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vault Adoption Dashboard</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body class="bg-gray-900 text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vault-adoption-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.19",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.4.5",
+    "vite": "^4.5.2",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.17"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import RadialMeter from './components/RadialMeter';
+import UseCaseChecklist from './components/UseCaseChecklist';
+import useCases from './data/useCases.json';
+import {
+  fetchAuthMethods,
+  fetchMounts,
+  fetchAuditDevices,
+  fetchReplicationStatus,
+  fetchNamespaces,
+  fetchEntities,
+  fetchPolicies
+} from './api/vaultClient';
+
+interface UseCaseItem {
+  name: string;
+  api: string;
+  check: string;
+  points: number;
+}
+
+const App: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [results, setResults] = useState<Record<string, any>>({});
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [auth, mounts, audit, replication, namespaces, entities, policies] = await Promise.all([
+          fetchAuthMethods(),
+          fetchMounts(),
+          fetchAuditDevices(),
+          fetchReplicationStatus(),
+          fetchNamespaces(),
+          fetchEntities(),
+          fetchPolicies()
+        ]);
+        setResults({
+          auth: auth.data,
+          mounts: mounts.data,
+          audit: audit.data,
+          replication: replication.data,
+          namespaces: namespaces.data,
+          entities: entities.data,
+          policies: policies.data
+        });
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const totalPoints = Object.values(useCases).flat().reduce((sum, uc: UseCaseItem) => sum + uc.points, 0);
+
+  const earnedPoints = Object.entries(useCases).reduce((acc, [category, list]) => {
+    return (
+      acc +
+      list.reduce((sum: number, item: UseCaseItem) => {
+        const data = (results as any)[item.api?.includes('auth') ? 'auth' : 'mounts'];
+        const enabled = JSON.stringify(data || {}).includes(item.check);
+        return sum + (enabled ? item.points : 0);
+      }, 0)
+    );
+  }, 0);
+
+  const percentage = totalPoints === 0 ? 0 : (earnedPoints / totalPoints) * 100;
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-100 p-4 font-mono">
+      {loading ? (
+        <div className="text-center text-blue-500">Loading...</div>
+      ) : (
+        <>
+          <div className="flex justify-center mb-6">
+            <RadialMeter percentage={percentage} />
+          </div>
+          {Object.entries(useCases).map(([category, list]) => {
+            const items = list.map((item: UseCaseItem) => {
+              const data = (results as any)[item.api?.includes('auth') ? 'auth' : 'mounts'];
+              const completed = JSON.stringify(data || {}).includes(item.check);
+              return { ...item, completed };
+            });
+            return <UseCaseChecklist key={category} title={category} items={items} />;
+          })}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default App;

--- a/src/api/vaultClient.ts
+++ b/src/api/vaultClient.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const VAULT_ADDR = import.meta.env.VITE_VAULT_ADDR || process.env.VAULT_ADDR;
+const VAULT_TOKEN = import.meta.env.VITE_VAULT_TOKEN || process.env.VAULT_TOKEN;
+
+const client = axios.create({
+  baseURL: VAULT_ADDR,
+  headers: { 'X-Vault-Token': VAULT_TOKEN }
+});
+
+export const fetchAuthMethods = () => client.get('/v1/sys/auth');
+export const fetchMounts = () => client.get('/v1/sys/mounts');
+export const fetchAuditDevices = () => client.get('/v1/sys/audit');
+export const fetchReplicationStatus = () => client.get('/v1/sys/replication/status');
+export const fetchNamespaces = () => client.get('/v1/identity/namespace');
+export const fetchEntities = () => client.get('/v1/identity/entity/name');
+export const fetchPolicies = () => client.get('/v1/sys/policies/acl');
+
+export default client;

--- a/src/components/RadialMeter.tsx
+++ b/src/components/RadialMeter.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface Props {
+  percentage: number;
+}
+
+export const RadialMeter: React.FC<Props> = ({ percentage }) => (
+  <div className="relative flex items-center justify-center w-40 h-40">
+    <svg className="absolute w-full h-full transform -rotate-90" viewBox="0 0 100 100">
+      <circle
+        className="text-gray-700"
+        strokeWidth="10"
+        stroke="currentColor"
+        fill="transparent"
+        r="45"
+        cx="50"
+        cy="50"
+      />
+      <circle
+        className="text-blue-500"
+        strokeWidth="10"
+        strokeDasharray={Math.PI * 2 * 45}
+        strokeDashoffset={Math.PI * 2 * 45 * (1 - percentage / 100)}
+        strokeLinecap="round"
+        stroke="currentColor"
+        fill="transparent"
+        r="45"
+        cx="50"
+        cy="50"
+      />
+    </svg>
+    <span className="text-white text-xl font-mono">{Math.round(percentage)}%</span>
+  </div>
+);
+
+export default RadialMeter;

--- a/src/components/UseCaseChecklist.tsx
+++ b/src/components/UseCaseChecklist.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface Item {
+  name: string;
+  completed: boolean;
+  points: number;
+}
+
+interface Props {
+  title: string;
+  items: Item[];
+}
+
+export const UseCaseChecklist: React.FC<Props> = ({ title, items }) => (
+  <div className="mb-4">
+    <h2 className="text-lg text-blue-400 font-mono mb-2">{title}</h2>
+    <ul className="space-y-1">
+      {items.map((item) => (
+        <li key={item.name} className="flex items-center text-gray-300">
+          <input
+            type="checkbox"
+            checked={item.completed}
+            readOnly
+            className="form-checkbox h-4 w-4 text-blue-500 mr-2"
+          />
+          <span className={item.completed ? 'line-through' : ''}>{item.name} ({item.points} pts)</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default UseCaseChecklist;

--- a/src/data/useCases.json
+++ b/src/data/useCases.json
@@ -1,0 +1,11 @@
+{
+  "Core Secrets Management": [
+    { "name": "KV Engine Enabled", "api": "/v1/sys/mounts", "check": "secret/", "points": 2 },
+    { "name": "Dynamic Secrets (e.g. database/)", "api": "/v1/sys/mounts", "check": "database/", "points": 4 }
+  ],
+  "Authentication": [
+    { "name": "AppRole Enabled", "api": "/v1/sys/auth", "check": "approle/", "points": 3 },
+    { "name": "OIDC or Okta", "api": "/v1/sys/auth", "check": "oidc/", "points": 3 },
+    { "name": "AWS IAM Method", "api": "/v1/sys/auth", "check": "aws/", "points": 3 }
+  ]
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        vaultBlue: '#3274d9'
+      }
+    },
+  },
+  plugins: [],
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- create React+Vite project structure
- add Vault API client helpers
- scaffold radial meter and checklist components
- implement adoption logic in App
- add Tailwind config and basic styling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685583565bdc832bb5dfcf385c49ad6d