### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install --global serve
+EXPOSE 4173
+CMD ["serve", "-s", "dist", "-l", "4173"]

--- a/README.md
+++ b/README.md
@@ -54,3 +54,14 @@ The dashboard now includes several charts to illustrate adoption progress and op
 - **Leader Information** – displays the current Vault leader address.
 
 API calls are made to `/v1/sys/mounts`, `/v1/sys/auth` and `/v1/sys/leader` via the new `vaultMetricsClient.ts` helper.
+
+## Docker
+
+A `Dockerfile` is included for containerised builds. To create the image and start the dashboard:
+
+```bash
+docker build -t vault-dashboard .
+docker run --env-file .env -p 4173:4173 vault-dashboard
+```
+
+The site will be available at `http://localhost:4173`.


### PR DESCRIPTION
## Summary
- containerize the dashboard with a new Dockerfile
- ignore development artifacts with `.dockerignore`
- document how to build and run the container

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden, cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_685955eda734832b91fc2ef14e9d1345