### PR TITLE
Allow pointing at existing Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ The site will be available at `http://localhost:4173`.
 
 ## Docker Compose
 
-A `docker-compose.yml` file is provided to run Vault, Prometheus and the
-dashboard together. The stack exposes Vault on `8200`, Prometheus on `9090`
-and the dashboard on `4173`.
+A `docker-compose.yml` file is provided to run the dashboard container. It reads
+`VAULT_ADDR`, `VAULT_TOKEN` and `PROMETHEUS_ADDR` from your `.env` file so the
+app can connect to an existing Vault instance.
 
-Start the full environment with:
+Start the container with:
 
 ```bash
 docker-compose up --build
 ```
 
-Environment variables from `.env` are passed to the dashboard at build time.
+Environment variables from `.env` are passed to the container at runtime.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,12 @@
 version: '3.8'
 
 services:
-  vault:
-    image: hashicorp/vault:1.15
-    container_name: vault
-    command: vault server -dev -dev-root-token-id=root -dev-listen-address=0.0.0.0:8200
-    ports:
-      - "8200:8200"
-    networks:
-      - vault-net
-
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-    command: '--config.file=/etc/prometheus/prometheus.yml'
-    ports:
-      - "9090:9090"
-    networks:
-      - vault-net
-
   dashboard:
     build: .
     container_name: vault-dashboard
-    depends_on:
-      - vault
-      - prometheus
     environment:
-      VAULT_ADDR: http://vault:8200
-      PROMETHEUS_ADDR: http://prometheus:9090
+      VAULT_ADDR: ${VAULT_ADDR}
+      VAULT_TOKEN: ${VAULT_TOKEN}
+      PROMETHEUS_ADDR: ${PROMETHEUS_ADDR}
     ports:
       - "4173:4173"
-    networks:
-      - vault-net
-
-networks:
-  vault-net:
-    driver: bridge


### PR DESCRIPTION
## Summary
- update docker-compose to remove bundled Vault service
- read Vault and Prometheus addresses from `.env`
- adjust README docs to run the dashboard against an external Vault

## Testing
- `npm run prereqs`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685960dcc31c832ba864218c3564cff5