### PR TITLE
Add Docker cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,13 @@ docker-compose up --build
 ```
 
 Environment variables from `.env` are passed to the container at runtime.
+
+To remove the container and clean up any related Docker resources, run the
+`unstack.sh` script:
+
+```bash
+bash scripts/unstack.sh
+```
+
+This stops the running container, removes the image and prunes any dangling
+images.

--- a/scripts/unstack.sh
+++ b/scripts/unstack.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Cleanup script for the Vault Adoption Dashboard
+# Stops and removes the Docker container and image built for the dashboard.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+if [ -f docker-compose.yml ]; then
+  echo "Stopping and removing containers via docker-compose..."
+  docker-compose down --volumes --remove-orphans --rmi local
+else
+  echo "docker-compose.yml not found. Attempting manual cleanup..."
+  if docker ps -a --format '{{.Names}}' | grep -q '^vault-dashboard$'; then
+    docker rm -f vault-dashboard
+  fi
+  if docker images --format '{{.Repository}}:{{.Tag}}' | grep -q '^vault-dashboard:latest$'; then
+    docker rmi -f vault-dashboard:latest
+  fi
+fi
+
+# Remove dangling images if any
+if command -v docker >/dev/null 2>&1; then
+  docker image prune -f >/dev/null 2>&1 || true
+fi
+
+echo "Cleanup complete."


### PR DESCRIPTION
## Summary
- add `unstack.sh` to tear down Docker containers and images
- document cleanup in README

## Testing
- `npm run prereqs`
- `bash scripts/unstack.sh` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ae3f90b08832b83eb4e06a981c050