### PR TITLE
Add stack.sh deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ A `docker-compose.yml` file is provided to run the dashboard container. It reads
 `VAULT_ADDR`, `VAULT_TOKEN` and `PROMETHEUS_ADDR` from your `.env` file so the
 app can connect to an existing Vault instance.
 
+If you are running the Vault stack from the companion repository, use the helper
+script to populate `.env` with the current `root_token` and start the container:
+
+```bash
+bash scripts/stack.sh
+```
+
 Start the container with:
 
 ```bash

--- a/scripts/stack.sh
+++ b/scripts/stack.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Deploy script for Vault Adoption Dashboard
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+STACK_JSON="/Users/zarkesh/Documents/GitHub/vault-stack/vault10-init.json"
+
+if [ ! -f "$STACK_JSON" ]; then
+  echo "Vault stack init file not found: $STACK_JSON" >&2
+  exit 1
+fi
+
+ROOT_TOKEN=$(grep -o '"root_token"[^"]*"[^"]*"' "$STACK_JSON" | sed -E 's/.*"root_token"[^"]*"([^"]*)"/\1/')
+
+if [ -z "$ROOT_TOKEN" ]; then
+  echo "Could not extract root_token from $STACK_JSON" >&2
+  exit 1
+fi
+
+ENV_FILE=".env"
+if [ ! -f "$ENV_FILE" ]; then
+  cp .env.example "$ENV_FILE"
+fi
+
+if grep -q '^VAULT_TOKEN=' "$ENV_FILE"; then
+  sed -i.bak "s/^VAULT_TOKEN=.*/VAULT_TOKEN=$ROOT_TOKEN/" "$ENV_FILE"
+else
+  echo "VAULT_TOKEN=$ROOT_TOKEN" >> "$ENV_FILE"
+fi
+
+rm -f "$ENV_FILE.bak"
+
+docker-compose up -d --build


### PR DESCRIPTION
## Summary
- add a helper script `scripts/stack.sh` that reads the Vault `root_token` from `vault10-init.json`, updates `.env` and starts the dashboard containers
- document the script usage in the README

## Testing
- `npm run build` *(fails: vite not found)*
- `bash scripts/check-prereqs.sh`


------
https://chatgpt.com/codex/tasks/task_e_685af402fe40832ba5f4820d44e4e2e9