### PR TITLE
Remove vault container and use env address for Prometheus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,3 @@ VAULT_ADDR=https://vault.mycompany.com
 VAULT_TOKEN=s.xxxxxxxx
 
 PROMETHEUS_ADDR=http://localhost:9090
-PROMETHEUS_TARGET=vault.mycompany.com:8200

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and the dashboard on `4173`.
 docker-compose up --build
 ```
 
-Environment variables from `.env` are passed to the dashboard and Prometheus at build time. Set `VAULT_ADDR`, `VAULT_TOKEN` and `PROMETHEUS_TARGET` to point at your existing Vault deployment.
+Environment variables from `.env` are passed to the dashboard and Prometheus at build time. Set `VAULT_ADDR` and `VAULT_TOKEN` to point at your existing Vault deployment.
 
 When you're finished, remove everything with:
 

--- a/scripts/stack.sh
+++ b/scripts/stack.sh
@@ -15,5 +15,9 @@ echo "Installing dependencies and building the dashboard..."
 npm install
 npm run build
 
+VAULT_ADDR_VALUE=$(grep -E '^VAULT_ADDR=' "$ENV_FILE" | cut -d= -f2-)
+PROMETHEUS_TARGET=$(echo "$VAULT_ADDR_VALUE" | sed -e 's#^[a-zA-Z]*://##')
+export PROMETHEUS_TARGET
+
 echo "Starting services with docker-compose..."
 docker-compose up -d --build


### PR DESCRIPTION
## Summary
- drop PROMETHEUS_TARGET from `.env.example`
- compute `PROMETHEUS_TARGET` from `VAULT_ADDR` in stack script
- update README usage notes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6853f184832b825f8518a5211e4f