### PR TITLE
Fix loading spinner not clearing without cluster

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,12 @@ const App: React.FC = () => {
   }, [token]);
 
   useEffect(() => {
-    if (!token || !currentCluster) return;
+    if (!token) return;
+    if (!currentCluster) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
     const load = async () => {
       try {
         const [auth, mounts, audit, replication, seal, policies, leaderResp, healthResp, leaderMetric, sealMetric, reqRate, errRate, tokenMetric, upMetric, peersMetric, storageMetric] = await Promise.all([


### PR DESCRIPTION
## Summary
- stop showing perpetual loading indicator when no cluster is selected
- show spinner again once a cluster is chosen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dc505e900832b8286df80b435afdb